### PR TITLE
#5 Create a supercut of search results

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+#!bash
+set -a
+. ./config.env
+set +a

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ elasticsearch_data
 
 # Exported JSON data
 app/static/json
+
+# Supercuts
+app/static/videos

--- a/.pylintrc
+++ b/.pylintrc
@@ -69,7 +69,8 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         # ACMI entries
-        missing-docstring
+        missing-docstring,
+        import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:alpine
 
+RUN apk add --update ffmpeg
+
 COPY ./requirements/base.txt /code/requirements/base.txt
 RUN pip install -Ur /code/requirements/base.txt
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	# Lint the python code
 	pylint *
 	flake8
-	isort -rc --check-only .
+	isort --check-only .
 test:
 	# Run python tests
 	pytest -v -s tests/tests.py

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,9 @@ up:
 	docker compose -f development/docker-compose.yml up
 down:
 	docker compose -f development/docker-compose.yml down
+build-local:
+	python3 -m venv venv && source venv/bin/activate && pip install -r requirements/base.txt
+down-local:
+	source venv/bin/activate && deactivate
+up-local:
+	source venv/bin/activate && python -u -m app.video

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -14,8 +14,9 @@ function setPlaybackTime(videoId, seconds) {
 
 document.addEventListener('DOMContentLoaded', function() {
   // Highlight query strings in search results
-  const searchQuery = document.querySelector('input[name="query"]').value.trim().toLowerCase();
+  let searchQuery = document.querySelector('input[name="query"]');
   if (searchQuery) {
+    searchQuery = searchQuery.value.trim().toLowerCase();
     const segments = document.querySelectorAll('.segment dd');
     segments.forEach(segment => {
       const textContent = segment.innerHTML;
@@ -27,4 +28,35 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
+
+  const video   = document.getElementById('supercut');
+  const credits = Array.from(
+    /** @type {NodeListOf<HTMLLIElement>} */
+    document.querySelectorAll('.supercut-credits li')
+  );
+
+  if (!video || credits.length === 0) return;
+
+  /* Turn per-clip durations into absolute start / end */
+  let totalRunningTime = 0;
+  credits.forEach(li => {
+    const duration = parseFloat(li.dataset.duration) || 0;
+    li.dataset.start = totalRunningTime;
+    totalRunningTime += duration;
+    li.dataset.end   = totalRunningTime;
+  });
+
+  /* Show only the credit that matches currentTime */
+  function updateCredits() {
+    const now = video.currentTime;
+    for (const li of credits) {
+      const start = parseFloat(li.dataset.start);
+      const end = parseFloat(li.dataset.end);
+      li.style.display = (now >= start && now < end) ? 'list-item' : 'none';
+    }
+  }
+
+  video.addEventListener('timeupdate',   updateCredits); // normal playback
+  video.addEventListener('seeked',       updateCredits); // user drags scrubber
+  video.addEventListener('loadedmetadata', updateCredits); // initial state
 }, false);

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -107,6 +107,14 @@ video {
     background-color: black;
 }
 
+label p, label input {
+    display: inline-block;
+}
+
+#supercut {
+    height: 40vh;
+}
+
 .container {
     display: block;
 }

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -89,6 +89,11 @@ button {
     background-color: black;
 }
 
+button.supercuts {
+    color: black;
+    background-color: gray;
+}
+
 h1, h2, h3, h4, strong {
     font-stretch: 95%;
     font-weight: 600;

--- a/app/static/styles/index.css
+++ b/app/static/styles/index.css
@@ -120,6 +120,16 @@ label p, label input {
     height: 40vh;
 }
 
+ol.supercut-credits, ol.supercut-credits li {
+    display: inline-block;
+    list-style: none;
+}
+
+ol.supercut-credits li {
+    margin: 0 1rem;
+    display: none;
+}
+
 .container {
     display: block;
 }

--- a/app/templates/detail.html
+++ b/app/templates/detail.html
@@ -30,6 +30,10 @@
                 <dd>{{ video._source.master_metadata.duration_hms }}</dd>
                 <dt>Metadata</dt>
                 <dd>{{ video._source.master_metadata.width }} x {{ video._source.master_metadata.height }} @ {{ video._source.master_metadata.video_frame_rate }} fps</dd>
+                {% if video._source.works|length > 0 %}
+                <dt>Work</dt>
+                <dd><a href="https://www.acmi.net.au/works/{{ video._source.works.0.id }}--{{ video._source.works.0.slug }}/" target="_blank">{{ video._source.works.0.title }}</a></dd>
+                {% endif %}
                 {% if export_json %}
                 <dt>JSON</dt>
                 <dd><a href="/static/json/{{ video._source.title }}.json">{{ video._source.title }}.json</a></dd>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,6 +36,20 @@
                 playsinline
             >
             </video>
+            <ol class="supercut-credits">
+                {% for result in results.hits.hits %}
+                    {% for segment in result._source.transcription.segments if query|lower in segment.text|lower %}
+                        <li data-duration="{{ segment|duration }}">
+                            {% if result._source.works|length > 0 %}
+                                <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
+                            {% else %}
+                                Untitled
+                            {% endif %}
+                            <br />{{ segment.start|int|seconds_to_timecode }} - {{ segment.end|int|seconds_to_timecode }}
+                        </li>
+                    {% endfor %}
+                {% endfor %}
+            </ol>
         {% endif %}
         <h3>Search results: {{ results.hits.total.value }}</h3>
         {% if results.hits.total.value > size %}
@@ -60,6 +74,9 @@
                 >
                 </video>
                 <h3><a href="/videos/{{ result._source.id }}/">{{ result._source.title }}</a></h3>
+                {% if result._source.works|length > 0 %}
+                    <p><a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a></p>
+                {% endif %}
                 <p><strong>Segments</strong>: </p>
                 {% if search_type == "audio" %}
                 <dl class="segments">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,16 +14,12 @@
     </header>
 
     <form action="/" method="get">
-        <input name="query" type="text" placeholder="Search terms" value="{% if query%}{{ query }}{% else %}{% endif %}" autofocus><button>Search</button><br />
+        <input name="query" type="text" placeholder="Search terms" value="{% if query%}{{ query }}{% else %}{% endif %}" autofocus><button>Search</button>{% if query and results %}<button type="submit" name="supercuts" value="on" class="supercuts">Supercut</button>{% endif %}<br />
         <select name="searchType" id="searchType" onchange="this.form.submit()">
             <option value="audio" {% if search_type == "audio" %}selected{% endif %}>Audio transcription</option>
             <option value="audioDescription" {% if search_type == "audioDescription" %}selected{% endif %}>Audio description</option>
             <option value="image" {% if search_type == "image" %}selected{% endif %}>Image frame content</option>
         </select>
-        <label for="supercuts">
-            <p>Create a supercut:</p>
-            <input type="checkbox" name="supercuts" id="supercuts" {% if supercuts %}checked{% endif %}>
-        </label>
     </form>
 
     {% if query and results %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,10 +20,28 @@
             <option value="audioDescription" {% if search_type == "audioDescription" %}selected{% endif %}>Audio description</option>
             <option value="image" {% if search_type == "image" %}selected{% endif %}>Image frame content</option>
         </select>
+        <label for="supercuts">
+            <p>Create a supercut:</p>
+            <input type="checkbox" name="supercuts" id="supercuts" {% if supercuts %}checked{% endif %}>
+        </label>
     </form>
 
     {% if query and results %}
-        <h3>Results: {{ results.hits.total.value }}</h3>
+        {% if supercut %}
+            <h2>Supercut:</h2>
+            <video
+                id="supercut"
+                src="{{ url_for('static', filename='videos/' + supercut) }}"
+                poster="{{ url_for('static', filename='videos/' + supercut|poster) }}"
+                controls
+                width="100%"
+                preload="none"
+                webkit-playsinline
+                playsinline
+            >
+            </video>
+        {% endif %}
+        <h3>Search results: {{ results.hits.total.value }}</h3>
         {% if results.hits.total.value > size %}
         <p>
             {% if page > 1 %}<a href="/?query={{ request.args.query }}&searchType={{ request.args.searchType }}&size={{ size }}&page={{ page - 1 }}">Previous</a>{% endif %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,6 +14,8 @@
     </header>
 
     <form action="/" method="get">
+        <input type="hidden" name="page" value="{{ page }}">
+        <input type="hidden" name="size" value="{{ size }}">
         <input name="query" type="text" placeholder="Search terms" value="{% if query%}{{ query }}{% else %}{% endif %}" autofocus><button>Search</button>{% if query and results %}<button type="submit" name="supercuts" value="on" class="supercuts">Supercut</button>{% endif %}<br />
         <select name="searchType" id="searchType" onchange="this.form.submit()">
             <option value="audio" {% if search_type == "audio" %}selected{% endif %}>Audio transcription</option>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -40,16 +40,44 @@
             </video>
             <ol class="supercut-credits">
                 {% for result in results.hits.hits %}
-                    {% for segment in result._source.transcription.segments if query|lower in segment.text|lower %}
-                        <li data-duration="{{ segment|duration }}">
-                            {% if result._source.works|length > 0 %}
-                                <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
-                            {% else %}
-                                Untitled
-                            {% endif %}
-                            <br />{{ segment.start|int|seconds_to_timecode }} - {{ segment.end|int|seconds_to_timecode }}
-                        </li>
-                    {% endfor %}
+                    {% if search_type == 'audio' %}
+                        {% for segment in result._source.transcription.segments if query|lower in segment.text|lower %}
+                            <li data-duration="{{ segment|duration }}">
+                                {% if result._source.works|length > 0 %}
+                                    <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
+                                {% else %}
+                                    Untitled
+                                {% endif %}
+                                <br />{{ segment.start|int|seconds_to_timecode }} - {{ segment.end|int|seconds_to_timecode }}
+                            </li>
+                        {% endfor %}
+                    {% elif search_type == 'image' %}
+                        {% for segment in result._source.classification.captions.huggingface %}
+                            {% for prediction in segment.predictions if query|lower in prediction.prediction|lower %}
+                                <li data-duration="{{ segment|duration }}">
+                                    {% if result._source.works|length > 0 %}
+                                        <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
+                                    {% else %}
+                                        Untitled
+                                    {% endif %}
+                                    <br />{{ segment.timestamp|int|seconds_to_timecode }}
+                                </li>
+                            {% endfor %}
+                        {% endfor %}
+                    {% elif search_type == 'audioDescription' %}
+                        {% for segment in result._source.classification.captions.clap %}
+                            {% for prediction in segment.predictions if query|lower in prediction.prediction|lower %}
+                                <li data-duration="{{ segment|duration }}">
+                                    {% if result._source.works|length > 0 %}
+                                        <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
+                                    {% else %}
+                                        Untitled
+                                    {% endif %}
+                                    <br />{{ segment.timestamp|int|seconds_to_timecode }}
+                                </li>
+                            {% endfor %}
+                        {% endfor %}
+                    {% endif %}
                 {% endfor %}
             </ol>
         {% endif %}

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -2,29 +2,38 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Generating Supercut</title>
+    <title>Generating a Supercut</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles/index.css') }}">
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            var source = new EventSource('/supercut_progress/{{ task_id }}');
-            source.onmessage = function(event) {
-                if (event.data.startsWith('completed')) {
-                    var filename = event.data.split(' ')[1];
-                    document.getElementById('progress').innerText = 'Supercut generated!';
-                    document.getElementById('supercut').src = '/static/videos/' + filename;
-                    document.getElementById('supercut').poster = '/static/videos/' + filename.replace('.mp4', '.jpg');
-                    document.getElementById('supercut').style.display = 'block';
-                    source.close();
-                } else if (event.data === 'no_clips') {
-                    document.getElementById('progress').innerText = 'No matching clips found.';
-                    source.close();
-                } else if (event.data.includes('saving')) {
-                    document.getElementById('progress').innerText = 'Saving your supercut... (this step takes a while)';
-                } else {
-                    var progress = parseInt(event.data);
-                    document.getElementById('progress').innerText = 'Progress: ' + progress + '%';
-                }
-            };
+            let source;
+            function connect() {
+                source = new EventSource('/supercut_progress/{{ task_id }}');
+                source.onmessage = function(event) {
+                    if (event.data.startsWith('completed')) {
+                        var filename = event.data.split(' ')[1];
+                        document.getElementById('progress').innerText = 'Supercut generated!';
+                        document.getElementById('supercut').src = '/static/videos/' + filename;
+                        document.getElementById('supercut').poster = '/static/videos/' + filename.replace('.mp4', '.jpg');
+                        document.getElementById('supercut').style.display = 'block';
+                        source.close();
+                    } else if (event.data === 'no_clips') {
+                        document.getElementById('progress').innerText = 'No matching clips found.';
+                        source.close();
+                    } else if (event.data.includes('saving')) {
+                        document.getElementById('progress').innerText = 'Saving your supercut... (this step takes a while)';
+                    } else {
+                        var progress = parseInt(event.data);
+                        document.getElementById('progress').innerText = 'Progress: ' + progress + '%';
+                    }
+                };
+                source.onerror = function(event) {
+                    if (source.readyState === EventSource.CLOSED) {
+                        setTimeout(connect, 2000);
+                    }
+                };
+            }
+            connect();
         });
     </script>
 </head>
@@ -32,7 +41,7 @@
     <header>
         <h1><a href="/">Video search</a></h1>
     </header>
-    <h2>Generating Supercut for "{{ query }}"</h2>
+    <h2>Generating a Supercut for "{{ query }}"</h2>
     <p id="progress">Progress: 0%</p>
     <video id="supercut" controls width="100%" style="display:none;" preload="none" webkit-playsinline playsinline></video>
     <footer>

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Generating a Supercut</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles/index.css') }}">
+    <script src="{{ url_for('static', filename='js/index.js') }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let source;
@@ -44,6 +45,20 @@
     <h2>Generating a Supercut for "{{ query }}"</h2>
     <p id="progress">Progress: 0%</p>
     <video id="supercut" controls width="100%" style="display:none;" preload="none" webkit-playsinline playsinline></video>
+    <ol class="supercut-credits">
+        {% for result in results.hits.hits %}
+            {% for segment in result._source.transcription.segments if query|lower in segment.text|lower %}
+                <li data-duration="{{ segment|duration }}">
+                    {% if result._source.works|length > 0 %}
+                        <a href="https://www.acmi.net.au/works/{{ result._source.works.0.id }}--{{ result._source.works.0.slug }}/" target="_blank">{{ result._source.works.0.title }}</a>
+                    {% else %}
+                        Untitled
+                    {% endif %}
+                    <br />{{ segment.start|int|seconds_to_timecode }} - {{ segment.end|int|seconds_to_timecode }}
+                </li>
+            {% endfor %}
+        {% endfor %}
+    </ol>
     <footer>
         <a href="https://www.acmi.net.au"><img src="{{ url_for('static', filename='images/acmi-logo.svg') }}" alt="ACMI - Australian Centre for the Moving Image" title="ACMI - Australian Centre for the Moving Image"></a>
     </footer>

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -18,6 +18,8 @@
                 } else if (event.data === 'no_clips') {
                     document.getElementById('progress').innerText = 'No matching clips found.';
                     source.close();
+                } else if (event.data.includes('saving')) {
+                    document.getElementById('progress').innerText = 'Saving your supercut...';
                 } else {
                     var progress = parseInt(event.data);
                     document.getElementById('progress').innerText = 'Progress: ' + progress + '%';

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Generating Supercut</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles/index.css') }}">
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var source = new EventSource('/supercut_progress/{{ task_id }}');
+            source.onmessage = function(event) {
+                if (event.data.startsWith('completed')) {
+                    var filename = event.data.split(' ')[1];
+                    document.getElementById('progress').innerText = 'Supercut generated!';
+                    document.getElementById('supercut').src = '/static/videos/' + filename;
+                    document.getElementById('supercut').poster = '/static/videos/' + filename.replace('.mp4', '.jpg');
+                    document.getElementById('supercut').style.display = 'block';
+                    source.close();
+                } else if (event.data === 'no_clips') {
+                    document.getElementById('progress').innerText = 'No matching clips found.';
+                    source.close();
+                } else {
+                    var progress = parseInt(event.data);
+                    document.getElementById('progress').innerText = 'Progress: ' + progress + '%';
+                }
+            };
+        });
+    </script>
+</head>
+<body>
+    <header>
+        <h1><a href="/">Video search</a></h1>
+    </header>
+    <h2>Generating Supercut for "{{ query }}"</h2>
+    <p id="progress">Progress: 0%</p>
+    <video id="supercut" controls width="100%" style="display:none;" preload="none" webkit-playsinline playsinline></video>
+    <footer>
+        <a href="https://www.acmi.net.au"><img src="{{ url_for('static', filename='images/acmi-logo.svg') }}" alt="ACMI - Australian Centre for the Moving Image" title="ACMI - Australian Centre for the Moving Image"></a>
+    </footer>
+</body>
+</html>

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -19,7 +19,7 @@
                     document.getElementById('progress').innerText = 'No matching clips found.';
                     source.close();
                 } else if (event.data.includes('saving')) {
-                    document.getElementById('progress').innerText = 'Saving your supercut...';
+                    document.getElementById('progress').innerText = 'Saving your supercut... (this step takes a while)';
                 } else {
                     var progress = parseInt(event.data);
                     document.getElementById('progress').innerText = 'Progress: ' + progress + '%';

--- a/app/video.py
+++ b/app/video.py
@@ -275,7 +275,8 @@ def poster_from_video_filter(video_file):
     return video_file.replace('.mp4', '.jpg')
 
 
-def generate_supercut_background(query, search_results, task_id):  # pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,too-many-statements
+def generate_supercut_background(query, search_results, task_id):
     """
     Run supercut generation in a background thread and update task status.
     """

--- a/app/video.py
+++ b/app/video.py
@@ -358,13 +358,6 @@ def generate_supercut_background(query, search_results, task_id):
             supercut_tasks[task_id]['filename'] = None
 
 
-def generate_supercut(query, search_results, task_id):
-    """
-    Helper function called by the background thread (not used directly here).
-    """
-    generate_supercut_background(query, search_results, task_id)
-
-
 class Search():
     """
     Elasticsearch interface.

--- a/app/video.py
+++ b/app/video.py
@@ -72,7 +72,7 @@ def home():
     else:
         # Try getting pre-generated supercuts as examples
         examples = [
-            stem.split('_')[1]
+            stem.split('_')[1].replace('-', ' ')
             for stem in (
                 p.stem
                 for p in Path('app/static/videos').glob('*.mp4')

--- a/app/video.py
+++ b/app/video.py
@@ -78,14 +78,14 @@ def home():
         examples = examples.strip().split(',')
     else:
         # Try getting pre-generated supercuts as examples
-        examples = [
+        examples = sorted([
             stem.split('_')[1].replace('-', ' ')
             for stem in (
                 p.stem
                 for p in Path('app/static/videos').glob('*.mp4')
             )
             if len(stem.split('_')) > 1
-        ]
+        ])
 
     if supercuts and query and results:
         filename = get_filename(query, page)

--- a/app/video.py
+++ b/app/video.py
@@ -17,6 +17,7 @@ from elasticsearch import Elasticsearch
 from flask import Flask, Response, render_template, request
 from moviepy import (ColorClip, CompositeVideoClip, VideoFileClip,
                      concatenate_videoclips)
+from moviepy.audio.fx import AudioFadeIn, AudioFadeOut
 from PIL import Image
 from slugify import slugify
 
@@ -316,6 +317,10 @@ def generate_supercut_background(query, search_results, task_id):
                 end_time = min(float(segment['end']) + 0.5, video.duration)
                 try:
                     clip = video.subclipped(start_time, end_time)
+                    # Fade the audio in and out
+                    fade_in = clip.audio.with_effects([AudioFadeIn(0.5)])
+                    fade_out = fade_in.with_effects([AudioFadeOut(0.5)])
+                    clip = clip.with_audio(fade_out)
                     clips.append(clip)
                 except ValueError:
                     pass

--- a/app/video.py
+++ b/app/video.py
@@ -298,8 +298,11 @@ def generate_supercut_background(query, search_results, task_id):  # pylint: dis
                 # Extend clip by 0.5 s on either side, but keep within the video’s bounds
                 start_time = max(float(segment['start']) - 0.5, 0)
                 end_time = min(float(segment['end']) + 0.5, video.duration)
-                clip = video.subclipped(start_time, end_time)
-                clips.append(clip)
+                try:
+                    clip = video.subclipped(start_time, end_time)
+                    clips.append(clip)
+                except ValueError:
+                    pass
                 processed_clips += 1
                 progress = (processed_clips / total_clips) * 100 if total_clips > 0 else 100
                 with lock:

--- a/app/video.py
+++ b/app/video.py
@@ -1,4 +1,5 @@
 import json
+import multiprocessing
 import os
 import re
 import statistics
@@ -300,7 +301,7 @@ def generate_supercut_background(query, search_results, task_id):  # pylint: dis
                     supercut_tasks[task_id]['progress'] = progress
 
     if clips:
-        target_resolution = (1920, 1080)
+        target_resolution = (1280, 720)
         resized_clips = []
         for clip in clips:
             # Resize to fit within target_resolution, preserving aspect ratio
@@ -320,7 +321,14 @@ def generate_supercut_background(query, search_results, task_id):  # pylint: dis
 
         supercut = concatenate_videoclips(resized_clips, method='compose')
         Path('app/static/videos').mkdir(exist_ok=True)
-        supercut.write_videofile(output_path, codec='libx264', audio_codec='aac')
+        supercut.write_videofile(
+            output_path,
+            codec='libx264',
+            audio_codec='aac',
+            preset='veryfast',
+            bitrate='2000k',
+            threads=multiprocessing.cpu_count(),
+        )
 
         processed_clips += 1
         progress = (processed_clips / total_clips) * 100 if total_clips > 0 else 100

--- a/app/video.py
+++ b/app/video.py
@@ -359,6 +359,9 @@ def generate_supercut_background(query, search_results, task_id, page, search_ty
     """
     filename = get_filename(query, page, search_type)
     output_path = f'app/static/videos/{filename}'
+    output_dir = os.path.dirname(output_path)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
     clip_jobs = []
     for hit in search_results['hits']['hits']:
         path = hit['_source']['web_resource']

--- a/app/video.py
+++ b/app/video.py
@@ -39,6 +39,7 @@ EXPORT_VIDEO_JSON = os.getenv('EXPORT_VIDEO_JSON', 'false').lower() == 'true'
 REMOVE_QUERY_PARAMS = os.getenv('REMOVE_QUERY_PARAMS', 'false').lower() == 'true'
 EXAMPLES = os.getenv('EXAMPLES', None)
 SUPERCUT_RESOLUTION = (1280, 720)
+IMAGE_AUDIO_CAPTION_DURATION = 4.5
 IS_MAC = platform.system() == 'Darwin'
 VIDEO_CODEC = 'h264_videotoolbox' if IS_MAC else 'libx264'
 PRESET = 'realtime' if IS_MAC else 'veryfast'
@@ -303,9 +304,11 @@ def duration_filter(segment):
     """
     Returns the duration of a segment.
     """
-    start_time = max(float(segment['start']) - 0.5, 0)
-    end_time = float(segment['end']) + 0.5
-    return end_time - start_time
+    if segment.get('start'):
+        start_time = max(float(segment['start']) - 0.5, 0)
+        end_time = float(segment['end']) + 0.5
+        return end_time - start_time
+    return IMAGE_AUDIO_CAPTION_DURATION + 0.5
 
 
 def get_filename(query, page, search_type):
@@ -376,14 +379,14 @@ def generate_supercut_background(query, search_results, task_id, page, search_ty
                 for prediction in segment['predictions']:
                     if query.lower() in prediction['prediction'].lower():
                         start = max(segment['timestamp'] - 0.5, 0)
-                        end = segment['timestamp'] + 4.5
+                        end = segment['timestamp'] + IMAGE_AUDIO_CAPTION_DURATION
                         clip_jobs.append((path, start, end, True))
         elif search_type == 'audioDescription':
             for segment in hit['_source']['classification']['captions']['clap']:
                 for prediction in segment['predictions']:
                     if query.lower() in prediction['prediction'].lower():
                         start = max(segment['timestamp'] - 0.5, 0)
-                        end = segment['timestamp'] + 4.5
+                        end = segment['timestamp'] + IMAGE_AUDIO_CAPTION_DURATION
                         clip_jobs.append((path, start, end, True))
 
     total_steps = len(clip_jobs) + 2

--- a/app/video.py
+++ b/app/video.py
@@ -229,14 +229,8 @@ def generate_supercut(query, search_results):
         video_path = result['_source']['web_resource']
         for segment in result['_source']['transcription']['segments']:
             if query.lower() in segment['text'].lower():
-                clip_length = 5.0
-                first_query_word = query.lower().split(' ')[0]
-                for index, word in enumerate(segment['text'].lower().split(' ')):
-                    if word == first_query_word:
-                        clip_length = index + 1
-                        break
                 video = VideoFileClip(video_path)
-                clip = video.subclipped(int(segment['start']), int(segment['start']) + clip_length)
+                clip = video.subclipped(float(segment['start']), float(segment['end']) + 0.5)
                 clips.append(clip)
 
     # Concatenate all clips

--- a/app/video.py
+++ b/app/video.py
@@ -87,7 +87,7 @@ def home():
             if len(stem.split('_')) > 1
         })
 
-    if supercuts and query and results:
+    if supercuts and query and results and results.get('hits') and results.get('hits').get('hits'):
         filename = get_filename(query, page, search_type)
         output_path = f'app/static/videos/{filename}'
         if os.path.isfile(output_path):

--- a/app/video.py
+++ b/app/video.py
@@ -94,6 +94,11 @@ def home():
                 'progress.html',
                 task_id=task_id,
                 query=query,
+                results=results,
+                search_type=search_type,
+                size=size,
+                page=page,
+                errors=errors,
             )
 
     return render_template(
@@ -273,6 +278,16 @@ def poster_from_video_filter(video_file):
     Returns the poster file name from a video file name.
     """
     return video_file.replace('.mp4', '.jpg')
+
+
+@application.template_filter('duration')
+def duration_filter(segment):
+    """
+    Returns the duration of a segment.
+    """
+    start_time = max(float(segment['start']) - 0.4, 0)
+    end_time = float(segment['end']) + 0.4
+    return end_time - start_time
 
 
 # pylint: disable=too-many-locals,too-many-statements

--- a/app/video.py
+++ b/app/video.py
@@ -295,7 +295,10 @@ def generate_supercut_background(query, search_results, task_id):  # pylint: dis
         for segment in result['_source']['transcription']['segments']:
             if query.lower() in segment['text'].lower():
                 video = VideoFileClip(video_path)
-                clip = video.subclipped(float(segment['start']), float(segment['end']) + 0.5)
+                # Extend clip by 0.5 s on either side, but keep within the video’s bounds
+                start_time = max(float(segment['start']) - 0.5, 0)
+                end_time = min(float(segment['end']) + 0.5, video.duration)
+                clip = video.subclipped(start_time, end_time)
                 clips.append(clip)
                 processed_clips += 1
                 progress = (processed_clips / total_clips) * 100 if total_clips > 0 else 100
@@ -315,7 +318,7 @@ def generate_supercut_background(query, search_results, task_id):  # pylint: dis
             background = ColorClip(size=target_resolution, color=(0, 0, 0), duration=clip.duration)
 
             # Center the resized clip on the background
-            padded_clip = CompositeVideoClip([background, resized_clip.with_position("center")])
+            padded_clip = CompositeVideoClip([background, resized_clip.with_position('center')])
             resized_clips.append(padded_clip)
 
         processed_clips += 1

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-RUN apk add --update make
+RUN apk add --update make ffmpeg
 
 COPY ./requirements/base.txt /code/requirements/base.txt
 COPY ./requirements/test.txt /code/requirements/test.txt

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+    ports:
+      - 8081:8081
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.15.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,6 @@ flask
 gunicorn
 pytz
 requests
-elasticsearch
+elasticsearch<9
 moviepy
 python-slugify

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ pytz
 requests
 elasticsearch
 moviepy
+python-slugify

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,4 @@ gunicorn
 pytz
 requests
 elasticsearch
+moviepy

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,6 +11,6 @@ else
         --pythonpath $PYTHON_PATH \
         --workers 2 \
         --bind 0.0.0.0:$PORT \
-        --timeout 120 \
+        --timeout 12000 \
         --reload
 fi


### PR DESCRIPTION
Resolves #5

Let's allow visitors to create supercuts of our collection video search results.

### Acceptance Criteria
- [x] Add an option to create a supercut of search results

### Relevant design files
* None

### Testing instructions
1. Build a local environment: `make build-local`
1. Start your environment: `make up-local`
1. Search for something: http://localhost:8081/?query=city+streets&searchType=audio
1. Press the `Supercut` button to generate a supercut of the results
1. Note when pressing `Supercut` a second time, the result is cached: http://localhost:8081/?query=city+streets&supercuts=on&searchType=audio