### PR TITLE
#7 Upgrade to elasticsearch v9

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 8081:8081
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
     hostname: video-search
     container_name: video-search
     restart: on-failure

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,6 @@ flask
 gunicorn
 pytz
 requests
-elasticsearch<9
+elasticsearch
 moviepy
 python-slugify


### PR DESCRIPTION
Resolves #7

Upgrade to elasticsearch v9.

### Acceptance Criteria
- [x] Upgrade to `elasticsearch` `v9` now that we've upgraded our cloud instance

### Relevant design files
* None

### Testing instructions
1. Re-build your containers with `DEBUG=true` in your `config.env`: `make build`
1. Connect to a Python shell: `docker exec -it video python3`
1. Inside that shell run:

```python
from app.video import Search
search = Search()
search.index_all()
```